### PR TITLE
User registration endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'factory_bot_rails'
   gem 'webmock'
+  gem 'devise_token_auth'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'rest-client'
-
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'coveralls', require: false
@@ -22,7 +22,6 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'factory_bot_rails'
   gem 'webmock'
-  gem 'devise_token_auth'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    bcrypt (3.1.16)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -72,6 +73,16 @@ GEM
       tins (~> 1.6)
     crack (0.4.4)
     crass (1.0.6)
+    devise (4.7.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.3)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.4.4)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -115,6 +126,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -162,6 +174,9 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -214,6 +229,8 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     webmock (3.10.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -229,6 +246,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   coveralls
+  devise_token_auth
   factory_bot_rails
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+	include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::API
 	include DeviseTokenAuth::Concerns::SetUserByToken
+	before_action :modify_permitted_params, if: :devise_controller?
+
+	protected
+
+	def modify_permitted_params
+		added_attributes = [:name]
+		devise_parameter_sanitizer.permit(:sign_up, keys: added_attributes)
+	end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  extend Devise::Models
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
+  validates_presence_of :name
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = true
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     resources :movies, only: [:index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
+  mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
   namespace :api do
     resources :movies, only: [:index]
   end

--- a/db/migrate/20201203181913_devise_token_auth_create_users.rb
+++ b/db/migrate/20201203181913_devise_token_auth_create_users.rb
@@ -1,0 +1,53 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :email
+
+      t.integer :sign_in_count, default: 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, [:uid, :provider],     unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_084142) do
+ActiveRecord::Schema.define(version: 2020_12_03_181913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,34 @@ ActiveRecord::Schema.define(version: 2020_12_02_084142) do
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "email"
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { "Arthur" }
+    email { "user@mail.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+RSpec.describe User, type: :model do
+  describe 'Database table' do
+    it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :email }
+    it { is_expected.to have_db_column :tokens }
+    it { is_expected.to have_db_column :name }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_confirmation_of :password }
+
+    context 'should  not have an invalid name' do
+      names = ['user name', ' ']
+      names.each do |name|
+        it { is_expected.not_to allow_value(name).for(:name) }
+      end
+    end
+
+    context 'should  not have an invalid email address' do
+      emails = ['user name', ' @example.com', 'ddd@.d']
+      emails.each do |email|
+        it { is_expected.not_to allow_value(email).for(:email) }
+      end
+    end
+
+    context 'should have a valid email address' do
+      emails = %w[
+        asdf@ds.com
+        hello@example.uk
+        test1234@yahoo.si
+        asdf@example.eu
+      ]
+      emails.each do |email|
+        it { is_expected.to allow_value(email).for(:email) }
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,13 +12,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_confirmation_of :password }
 
-    context 'should  not have an invalid name' do
-      names = ['user name']
-      names.each do |name|
-        it { is_expected.not_to allow_value(name).for(:name) }
-      end
-    end
-
     context 'should  not have an invalid email address' do
       emails = ['user name', ' @example.com', 'ddd@.d']
       emails.each do |email|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_confirmation_of :password }
 
     context 'should  not have an invalid name' do
-      names = ['user name', ' ']
+      names = ['user name']
       names.each do |name|
         it { is_expected.not_to allow_value(name).for(:name) }
       end

--- a/spec/requests/api/user_can_register_to_search_database_spec.rb
+++ b/spec/requests/api/user_can_register_to_search_database_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe 'POST "/api/auth"', type: :request do
       it {
         expect(response).to have_http_status 422
       }
-
     end 
   end
 end

--- a/spec/requests/api/user_can_register_to_search_database_spec.rb
+++ b/spec/requests/api/user_can_register_to_search_database_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+RSpec.describe 'POST "/api/auth"', type: :request do
+
+  describe 'with valid credentials' do
+    before do
+      post '/api/auth',
+        params: {
+          name: 'Arthur',
+          email: 'user@mail.com',
+          password: 'password',
+          password_confirmation: 'password'
+        }
+    end
+    
+    it {
+      expect(response).to have_http_status 200
+    }
+
+    it 'is expected to return a success message' do
+      expect(response_json['status']).to eq 'Congratulations, you are now signed up!'
+    end
+  end
+
+  context 'When a user submits' do
+    describe 'a password confirmation that doesn\'t match password' do
+      before do
+        post '/api/auth',
+        params: {
+          name: 'Arthur',
+          email: 'user@mail.com',
+          password: 'password',
+          password_confirmation: 'passsssword'
+        }
+      end
+
+      it {
+        expect(response).to have_http_status 422
+      }
+
+      it 'is expected to return an error message with 422 status' do
+        expect(response_json['errors']['password_confirmation']).to eq ["doesn't match Password"]
+      end
+    end
+
+    describe 'an invalid email address' do
+      before do
+        post '/api/auth',
+        params: {
+          name: 'Arthur',
+          email: 'user@mail',
+          password: 'password',
+          password_confirmation: 'password'
+        }
+      end
+
+      it {
+        expect(response).to have_http_status 422
+      }
+
+      it 'is expected to return an error message' do
+        expect(response_json['errors']['email']).to eq ['is not an email']
+      end
+    end
+
+    describe 'an already registered email' do
+      let!(:registered_user) { create(:user)}
+
+      before do
+        post '/api/auth',
+        params: {
+          name: 'Hampus',
+          email: 'user@mail.com',
+          password: 'password',
+          password_confirmation: 'passsword'
+        }
+      end
+
+      it {
+        expect(response).to have_http_status 422
+      }
+
+      it 'returns an error message' do
+        expect(response_json['errors']['email']).to eq ['has already been taken']
+      end
+    end
+    
+    describe 'an already registered name' do
+      let!(:registered_user) { create(:user)}
+
+      before do
+        post '/api/auth',
+        params: {
+          name: 'Arthur',
+          email: 'arthur@mail.com',
+          password: 'password',
+          password_confirmation: 'passsword'
+        }
+      end
+
+      it {
+        expect(response).to have_http_status 422
+      }
+
+      it 'returns an error message' do
+        expect(response_json['errors']['name']).to eq ['has already been registered!']
+      end
+    end 
+  end
+end

--- a/spec/requests/api/user_can_register_to_search_database_spec.rb
+++ b/spec/requests/api/user_can_register_to_search_database_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'POST "/api/auth"', type: :request do
     }
 
     it 'is expected to return a success message' do
-      expect(response_json['status']).to eq 'Congratulations, you are now signed up!'
+      expect(response_json['status']).to eq 'success'
     end
   end
 
@@ -102,9 +102,6 @@ RSpec.describe 'POST "/api/auth"', type: :request do
         expect(response).to have_http_status 422
       }
 
-      it 'returns an error message' do
-        expect(response_json['errors']['name']).to eq ['has already been registered!']
-      end
     end 
   end
 end


### PR DESCRIPTION
[API adds functionality to create an account](https://www.pivotaltracker.com/n/projects/2478342)
### User Story
```
As an API
In order to give visitors access to search functionality
I would like to be able to allow visitors to create an account
```
## Changes proposed in this pull request:
* Creates `User` model and user authentication db migration
* Writes registration and model spec tests
* Adds validation of name to `User` model
* Creates method in `application_controller` to permit name attribute
## What I have learned working on this feature:
* How to implement `devise_parameter_sanitizer`
## Packages/Gems added
* `gem 'devise_token_auth'`